### PR TITLE
[FIX] Should only use statement line reference for matching

### DIFF
--- a/l10n_fi_reconcile/models/account_bank_statement.py
+++ b/l10n_fi_reconcile/models/account_bank_statement.py
@@ -125,7 +125,7 @@ class AccountBankStatementLine(models.Model):
 
         match_recs = self._get_match_recs()
         if not match_recs:
-            _logger.debug('No reconciliation match found for %s' % self)
+            _logger.info('No reconciliation match found for %s' % self)
             return False
         # Now reconcile
         counterpart_aml_dicts = []
@@ -150,7 +150,7 @@ class AccountBankStatementLine(models.Model):
                     payment_aml_rec=payment_aml_rec,
                     new_aml_dicts=self._get_auto_reconcile_new_aml_dicts(
                         match_recs))
-                _logger.debug('Reconciled %s with %s' % (self, counterpart))
+                _logger.info('Reconciled %s with %s' % (self, counterpart))
             return counterpart
         except UserError:
             # A configuration / business logic error that makes it impossible
@@ -159,7 +159,7 @@ class AccountBankStatementLine(models.Model):
             # exception when manually reconciling. Other types of exception
             # are (hopefully) programmation errors and should cause a
             # stacktrace.
-            _logger.debug('Reconciliation failed for %s' % self)
+            _logger.info('Reconciliation failed for %s' % self)
             self.invalidate_cache()
             self.env['account.move'].invalidate_cache()
             self.env['account.move.line'].invalidate_cache()

--- a/l10n_fi_reconcile/models/account_bank_statement.py
+++ b/l10n_fi_reconcile/models/account_bank_statement.py
@@ -83,7 +83,7 @@ class AccountBankStatementLine(models.Model):
                       self.journal_id.default_debit_account_id.id),
                   'amount': float_round(amount, precision_digits=precision),
                   'partner_id': self.partner_id.id,
-                  'ref': self.ref or self.name,
+                  'ref': self.ref,
                   'currency': currency,
                   'amount_field': amount_field,
                   'liquidity_field': liquidity_field

--- a/l10n_fi_reconcile/tests/test_auto_reconcile.py
+++ b/l10n_fi_reconcile/tests/test_auto_reconcile.py
@@ -1,0 +1,78 @@
+from odoo.tests.common import SavepointCase
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class ReconciliationPropositionTestCase(SavepointCase):
+    # To run this test case, install a chart of account in the same test run
+    # before running tests on this module
+
+    post_install = True
+    at_install = False
+
+    @classmethod
+    def setUpClass(cls):
+        super(ReconciliationPropositionTestCase, cls).setUpClass()
+        cls.env.user.company_id.auto_reconcile_method = "finnish"
+        domain = [('company_id', '=', cls.env.ref('base.main_company').id)]
+        if not cls.env['account.account'].search_count(domain):
+            cls.skipTest("No Chart of account found")
+
+        cls.journal = cls.env['account.journal'].search(
+            [('type', '=', 'sale')], limit=1)
+        assert cls.journal, "There isn't a single sale journal in the system"
+        cls.reference = "000111222333999"
+        cls.invoice = cls.env['account.invoice'].create({
+            'type': 'out_invoice',
+            'journal_id': cls.journal.id,
+            'partner_id': cls.env['res.partner'].search([('customer', '=', True)], limit=1).id,
+            'payment_reference': cls.reference,
+            'invoice_line_ids': [(0, 0, {
+                'name': 'An invoice line',
+                'account_id': cls.env['account.account'].search([], limit=1).id,
+                'quantity': 1,
+                'price_unit': 100,
+            })]
+        })
+        cls.invoice.action_invoice_open()
+        cls.to_reconcile = cls.invoice.move_id.line_ids
+
+        bank_account = cls.env['account.bank.statement'].with_context(
+            journal_type='bank')._default_journal()
+        assert bank_account, "No bank account"
+        cls.statement = cls.env['account.bank.statement'].create({'journal_id': bank_account.id})
+
+    def test_010_auto_reconcile_should_find_match_from_invoice(self):
+        statement_line = self.env['account.bank.statement.line'].create({
+            'statement_id': self.statement.id,
+            'name': "Some kind of payment",
+            'ref': self.reference,
+            'amount': 100,
+        })
+        match = statement_line._get_match_recs()
+        self.assertEqual(len(match), 1,
+                         msg="Logic should have found exactly one match")
+        self.assertIn(match, self.to_reconcile)
+
+    def test_020_auto_reconcile_should_not_match_if_ref_mismatch(self):
+        statement_line = self.env['account.bank.statement.line'].create({
+            'statement_id': self.statement.id,
+            'name': "Some kind of payment",
+            'ref': "some_fake_reference_that_should_not_exist",
+            'amount': 100,
+        })
+        match = statement_line._get_match_recs()
+        # Use is to differentiate falsy values: we expect the boolean False
+        self.assertIs(match, False)
+
+    def test_030_auto_reconcile_should_not_match_if_price_mismatch(self):
+        statement_line = self.env['account.bank.statement.line'].create({
+            'statement_id': self.statement.id,
+            'name': "Some kind of payment",
+            'ref': self.reference,
+            'amount': 100 - 20,
+        })
+        match = statement_line._get_match_recs()
+        # Use is to differentiate falsy values: we expect the boolean False
+        self.assertIs(match, False)


### PR DESCRIPTION
In finnish banking contexts it is not possible to generate bank
statements with references in random positions: they are mostly
required. As such it makes no sense to fall back to the label of the
statement line if the reference is missing: in the rare cases that the
reference is missing, finnish users do not want the system to do
automatic reconciliation, because it is an exception rather than a
rule.