### PR TITLE
Validate reconcile

### DIFF
--- a/l10n_fi_reconcile/models/account_bank_statement.py
+++ b/l10n_fi_reconcile/models/account_bank_statement.py
@@ -109,7 +109,8 @@ class AccountBankStatementLine(models.Model):
         auto reconciling complex situations, e.g. cash discounts.
         This stub method may be extended to handle those situations.
         """
-        return None
+        return []
+
 
     @api.multi
     def auto_reconcile(self):


### PR DESCRIPTION
Improve auto reconciliation process by adding an extensible way to check that the proposed account.move.line(s) are a valid match to the bank statement line. 